### PR TITLE
Fix Windows Compile

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -51,7 +51,7 @@ namespace api {
 			b = tmp;
 		}
 
-		max(machine, a, min(machine, b, c));
+		return max(machine, a, min(machine, b, c));
 	}
 
 	float sin(neko *machine, float a) {

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -2,6 +2,7 @@
 #include <console.hpp>
 #include <api.hpp>
 #include <iostream>
+#include <cctype>
 #include <algorithm>
 #include <carts.hpp>
 


### PR DESCRIPTION
A function in `api` was missing a `return`, and in windows you need to include `cctype` for `std::isstring`.